### PR TITLE
fix(): Glossary filestream closing

### DIFF
--- a/Glossary.cs
+++ b/Glossary.cs
@@ -121,16 +121,16 @@ namespace DocumentTranslationService.Core
                 await semaphore.WaitAsync();
                 try
                 {
-                    using FileStream fileStream = File.OpenRead(glossary.Key);
-                    BlobClient blobClient = new(translationService.StorageConnectionString, glossaryContainer.Name, DocumentTranslationBusiness.Normalize(glossary.Key));
-                    uploads.Add(blobClient.UploadAsync(fileStream, true));
+                    var filename = glossary.Key;
+                    BlobClient blobClient = new(translationService.StorageConnectionString, glossaryContainer.Name, DocumentTranslationBusiness.Normalize(filename));
+                    uploads.Add(blobClient.UploadAsync(filename, true));
                     var sasUriGlossaryBlob = blobClient.GenerateSasUri(BlobSasPermissions.All, DateTimeOffset.UtcNow + TimeSpan.FromHours(5));
                     TranslationGlossary translationGlossary = new(sasUriGlossaryBlob, Path.GetExtension(glossary.Key)[1..].ToUpperInvariant());
                     Glossaries[glossary.Key] = translationGlossary;
                     fileCounter++;
-                    uploadSize += new FileInfo(fileStream.Name).Length;
+                    uploadSize += new FileInfo(filename).Length;
                     semaphore.Release();
-                    Debug.WriteLine(String.Format($"Glossary file {fileStream.Name} uploaded."));
+                    Debug.WriteLine(String.Format($"Glossary file {filename} uploaded."));
                 }
                 catch (System.IO.IOException ex)
                 {


### PR DESCRIPTION
The using before the filestream was disposing of it when going out of scope (out of the try catch). If the UploadAsync didn't access what it had to access before that the program would crash. By simply using the UploadAsync with the filename we solve this issue since the UploadAsycn will handle opening and closing the stream