### PR TITLE
Add capability to translate local formats

### DIFF
--- a/LocalFormats/CaptionInfo.cs
+++ b/LocalFormats/CaptionInfo.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SRT2Markdown
+{
+    /// <summary>
+    /// Holds the attributes of a single caption for SRT/VTT files.
+    /// </summary>
+    internal struct CaptionInfo
+    {
+        /// <summary>
+        /// Holds the sequence number of the caption
+        /// Sequence numbers in SRT files start at 1
+        /// </summary>
+        public int SequenceNumber { get; set; }
+        
+        /// <summary>
+        /// Holds the time code of the caption
+        /// </summary>
+        public string TimeCode { get; set; }
+        
+        /// <summary>
+        /// Denotes the number of lines in the caption and their lengths
+        /// </summary>
+        public List<int> StringLengths { get; set; }
+
+        /// <summary>
+        /// Indicates whether the caption is a continuous sentence with the other lines of this caption
+        /// </summary>
+        public bool Continuous { get; set; }
+
+        public CaptionInfo()
+        {
+            SequenceNumber = 0;
+            TimeCode = string.Empty;
+            StringLengths = new();
+            Continuous = true;
+        }
+
+        public void Clear()
+        {
+            SequenceNumber = 0;
+            TimeCode = string.Empty;
+            StringLengths?.Clear();
+            Continuous = true;
+        }
+    }
+}

--- a/LocalFormats/LocalDocumentTranslationFileFormat.cs
+++ b/LocalFormats/LocalDocumentTranslationFileFormat.cs
@@ -7,6 +7,9 @@ using System.Threading.Tasks;
 
 namespace DocumentTranslationService.LocalFormats
 {
+    public delegate string ConvertToMarkdown(string[] input);
+    public delegate string ConvertFromMarkdown(string input);
+
     /// <summary>
     /// Hold the information about a file format, the associated extensions, and  how it can be converted to and from Markdown.
     /// </summary>
@@ -20,7 +23,7 @@ namespace DocumentTranslationService.LocalFormats
             ConvertFromMarkdown = null;
         }
 
-        public LocalDocumentTranslationFileFormat(string name, List<string> extensions, Delegate convertToMarkdown, Delegate convertFromMarkdown) : this(name, extensions)
+        public LocalDocumentTranslationFileFormat(string name, List<string> extensions, ConvertToMarkdown convertToMarkdown, ConvertFromMarkdown convertFromMarkdown) : this(name, extensions)
         {
             ConvertToMarkdown = convertToMarkdown;
             ConvertFromMarkdown = convertFromMarkdown;
@@ -28,8 +31,8 @@ namespace DocumentTranslationService.LocalFormats
 
         public string Format { get; set; }
         public List<string> FileExtensions { get; set; }
-        public Delegate ConvertToMarkdown { get; set; }
-        public Delegate ConvertFromMarkdown { get; set; }
+        public ConvertToMarkdown ConvertToMarkdown { get; set; }
+        public ConvertFromMarkdown ConvertFromMarkdown { get; set; }
         public readonly bool IsLocal => ConvertToMarkdown != null && ConvertFromMarkdown != null;
     }
 }

--- a/LocalFormats/LocalDocumentTranslationFileFormat.cs
+++ b/LocalFormats/LocalDocumentTranslationFileFormat.cs
@@ -1,0 +1,35 @@
+﻿using Azure.AI.Translation.Document;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DocumentTranslationService.LocalFormats
+{
+    /// <summary>
+    /// Hold the information about a file format, the associated extensions, and  how it can be converted to and from Markdown.
+    /// </summary>
+    public struct LocalDocumentTranslationFileFormat
+    {
+        public LocalDocumentTranslationFileFormat(string name, List<string> extensions) : this()
+        {
+            Format = name;
+            FileExtensions = extensions;
+            ConvertToMarkdown = null;
+            ConvertFromMarkdown = null;
+        }
+
+        public LocalDocumentTranslationFileFormat(string name, List<string> extensions, Delegate convertToMarkdown, Delegate convertFromMarkdown) : this(name, extensions)
+        {
+            ConvertToMarkdown = convertToMarkdown;
+            ConvertFromMarkdown = convertFromMarkdown;
+        }
+
+        public string Format { get; set; }
+        public List<string> FileExtensions { get; set; }
+        public Delegate ConvertToMarkdown { get; set; }
+        public Delegate ConvertFromMarkdown { get; set; }
+        public readonly bool IsLocal => ConvertToMarkdown != null && ConvertFromMarkdown != null;
+    }
+}

--- a/LocalFormats/LocalFormats.cs
+++ b/LocalFormats/LocalFormats.cs
@@ -1,6 +1,8 @@
 ﻿using SRT2Markdown;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 
 namespace DocumentTranslationService.LocalFormats
 {
@@ -11,6 +13,11 @@ namespace DocumentTranslationService.LocalFormats
     /// </summary>
     public static class LocalFormats
     {
+        /// <summary>
+        /// List of formats that can be converted to and from Markdown
+        /// Add to this list to add additional local file formats. 
+        /// Extension must start with a period and be all lowercase.
+        /// </summary>
         public static readonly List<LocalDocumentTranslationFileFormat> Formats = new() { new LocalDocumentTranslationFileFormat()
         {
             Format = "SubRip",
@@ -18,5 +25,141 @@ namespace DocumentTranslationService.LocalFormats
             ConvertToMarkdown = SRTMarkdownConverter.ConvertToMarkdown,
             ConvertFromMarkdown = SRTMarkdownConverter.ConvertToSRT
         } };
+
+        /// <summary>
+        /// Creates a new list of files to process, replacing the original filename where a local converter exists, with a temporary file in MarkDown format
+        /// </summary>
+        /// <param name="filenames">Original set of file names</param>
+        /// <returns>List of service-translatable file names</returns>
+        /// <exception cref="Exception">No converter found for this file's format</exception>
+        public static List<string> PreprocessSourceFiles(List<string> filenames)
+        {
+            List<string> result = new();
+            foreach (string filename in filenames)
+            {
+                if (IsLocalFormat(filename))
+                {
+                    var format = Formats.Find(f => f.FileExtensions.Contains(Path.GetExtension(filename.ToLowerInvariant())));
+                    if (format.ConvertToMarkdown != null)
+                    {
+                        Debug.WriteLine($"Converting {filename} to Markdown");
+                        string markdown = format.ConvertToMarkdown(File.ReadAllLines(filename));
+                        string newFilename = Path.Combine(Path.GetTempPath(), Path.GetFileName(filename) + ".md");
+                        File.WriteAllText(newFilename, markdown);
+                        result.Add(newFilename);
+                    }
+                    else throw new Exception($"No conversion function found for {filename}, but listed as local format.");
+                }
+                else result.Add(filename);
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// After translation, convert from MarkDown back to original format
+        /// </summary>
+        /// <param name="filenames">List of filenames, whether they need conversion or not</param>
+        /// <exception cref="Exception">Exception if there is noi conversion function found for this filename extension</exception>
+        public static void PostprocessTargetFiles(List<string> filenames)
+        {
+            foreach (string filename in filenames)
+            {
+                if (IsLocalFormat(filename, out string originalextension))
+                {
+                    var format = Formats.Find(f => f.FileExtensions.Contains(originalextension));
+                    if (format.ConvertFromMarkdown != null)
+                    {
+                        Debug.WriteLine($"Converting {filename} from Markdown to {originalextension}");
+                        string markdown = File.ReadAllText(filename);
+                        string newFilename = filename[..filename.LastIndexOf('.')];
+                        File.WriteAllText(newFilename, format.ConvertFromMarkdown(markdown));
+                        #if !DEBUG
+                        File.Delete(filename);
+                        #endif
+                    }
+                    else throw new Exception($"No conversion function found for {filename}, but listed as local format.");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Determine if the file is a locally processed format
+        /// </summary>
+        /// <param name="filename">Single file name</param>
+        /// <returns>TRUE if this is a locally converted file</returns>
+        private static bool IsLocalFormat(string filename)
+        {
+            foreach (var format in Formats)
+            {
+                if (format.IsLocal)
+                {
+                    if (format.FileExtensions.Contains(Path.GetExtension(filename.ToLowerInvariant())))
+                        return true;
+                }
+            }
+            return false;
+        }
+
+
+
+        /// <summary>
+        /// In post-processing: Determine if the file is a local format, and if so, return the original extension.
+        /// </summary>
+        /// <param name="filename">Post-processed file name</param>
+        /// <param name="originalextension">Return the original extension</param>
+        /// <returns>True of the original extension indicates local processing was necessary</returns>
+        private static bool IsLocalFormat(string filename, out string originalextension)
+        {
+            string _originalextension = GetSubstringBetweenLastTwoPeriods(filename)?.ToLower();
+            if (string.IsNullOrEmpty(_originalextension))
+            {
+                originalextension = null;
+                return false;
+            }
+            foreach (var format in Formats)
+            {
+                if (format.IsLocal)
+                {
+                    if (
+                        (Path.GetExtension(filename.ToLowerInvariant()) == ".md") &&
+                        format.FileExtensions.Contains("." + _originalextension)
+                        )
+                    {
+                        originalextension = "." + _originalextension;
+                        return true;
+                    }
+                    else
+                        originalextension = Path.GetExtension(filename.ToLowerInvariant());
+                    return false;
+                }
+            }
+            originalextension = Path.GetExtension(filename.ToLowerInvariant());
+            return false;
+        }
+
+
+        private static string GetSubstringBetweenLastTwoPeriods(string input)
+        {
+            int lastPeriodIndex = input.LastIndexOf('.');
+            int secondToLastPeriodIndex = input.LastIndexOf('.', lastPeriodIndex - 1);
+
+            if(lastPeriodIndex == -1)
+            {
+                // If there is no period, return null.
+                return null;
+            }
+                                                      
+            if (secondToLastPeriodIndex == -1)
+            {
+                // If there is only one period or none, return null.
+                return null;
+            }
+
+            int startIndex = secondToLastPeriodIndex + 1;
+            int length = lastPeriodIndex - startIndex;
+
+            string substring = input.Substring(startIndex, length);
+            return substring;
+        }
     }
 }

--- a/LocalFormats/LocalFormats.cs
+++ b/LocalFormats/LocalFormats.cs
@@ -1,0 +1,34 @@
+﻿using SRT2Markdown;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DocumentTranslationService.LocalFormats
+{
+    /// <summary>
+    /// Extensible list of locally converted formats. Add any new formats here
+    /// Underlying assumption is that the format translated by the service is Markdown.
+    /// You supply the functions to convert the local format to Markdown and from Markdown.
+    /// </summary>
+    public class LocalFormats
+    {
+        public readonly List<FormatInfo> Formats = new() { new FormatInfo()
+        {
+            Name = "SRT",
+            Extensions = { ".srt" },
+            ConvertToMarkdown = SRTMarkdownConverter.ConvertToMarkdown,
+            ConvertFromMarkdown = SRTMarkdownConverter.ConvertToSRT
+        } };
+    }
+
+    public struct FormatInfo
+    {
+        public string Name { get; set; }
+        public List<string> Extensions { get; set; }
+        public Delegate ConvertToMarkdown { get; set; }
+        public Delegate ConvertFromMarkdown { get; set; }
+    }
+}

--- a/LocalFormats/LocalFormats.cs
+++ b/LocalFormats/LocalFormats.cs
@@ -9,25 +9,14 @@ namespace DocumentTranslationService.LocalFormats
     /// Underlying assumption is that the format translated by the service is Markdown.
     /// You supply the functions to convert the local format to Markdown and from Markdown.
     /// </summary>
-    public class LocalFormats
+    public static class LocalFormats
     {
-        public readonly List<FormatInfo> Formats = new() { new FormatInfo()
+        public static readonly List<LocalDocumentTranslationFileFormat> Formats = new() { new LocalDocumentTranslationFileFormat()
         {
-            Name = "SRT",
-            Extensions = { ".srt" },
+            Format = "SubRip",
+            FileExtensions = new() { ".srt" },
             ConvertToMarkdown = SRTMarkdownConverter.ConvertToMarkdown,
             ConvertFromMarkdown = SRTMarkdownConverter.ConvertToSRT
         } };
-    }
-
-    /// <summary>
-    /// Holds the information about a format that can be converted to and from Markdown.
-    /// </summary>
-    public struct FormatInfo
-    {
-        public string Name { get; set; }
-        public List<string> Extensions { get; set; }
-        public Delegate ConvertToMarkdown { get; set; }
-        public Delegate ConvertFromMarkdown { get; set; }
     }
 }

--- a/LocalFormats/LocalFormats.cs
+++ b/LocalFormats/LocalFormats.cs
@@ -73,9 +73,11 @@ namespace DocumentTranslationService.LocalFormats
                         string markdown = File.ReadAllText(filename);
                         string newFilename = filename[..filename.LastIndexOf('.')];
                         File.WriteAllText(newFilename, format.ConvertFromMarkdown(markdown));
-                        #if !DEBUG
+                        //#if !DEBUG
+                        //Delete the temporary files
                         File.Delete(filename);
-                        #endif
+                        File.Delete(Path.Combine(Path.GetTempPath(), Path.GetFileName(filename)));
+                        //#endif
                     }
                     else throw new Exception($"No conversion function found for {filename}, but listed as local format.");
                 }

--- a/LocalFormats/LocalFormats.cs
+++ b/LocalFormats/LocalFormats.cs
@@ -1,10 +1,6 @@
 ﻿using SRT2Markdown;
 using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DocumentTranslationService.LocalFormats
 {
@@ -24,6 +20,9 @@ namespace DocumentTranslationService.LocalFormats
         } };
     }
 
+    /// <summary>
+    /// Holds the information about a format that can be converted to and from Markdown.
+    /// </summary>
     public struct FormatInfo
     {
         public string Name { get; set; }

--- a/LocalFormats/SRTCaptionInfo.cs
+++ b/LocalFormats/SRTCaptionInfo.cs
@@ -9,7 +9,7 @@ namespace SRT2Markdown
     /// <summary>
     /// Holds the attributes of a single caption for SRT/VTT files.
     /// </summary>
-    internal struct CaptionInfo
+    internal struct SRTCaptionInfo
     {
         /// <summary>
         /// Holds the sequence number of the caption
@@ -32,7 +32,7 @@ namespace SRT2Markdown
         /// </summary>
         public bool Continuous { get; set; }
 
-        public CaptionInfo()
+        public SRTCaptionInfo()
         {
             SequenceNumber = 0;
             TimeCode = string.Empty;

--- a/LocalFormats/SRTMarkdownConverter.cs
+++ b/LocalFormats/SRTMarkdownConverter.cs
@@ -1,0 +1,144 @@
+﻿using System.Text.Json;
+
+namespace SRT2Markdown
+{
+    public static class SRTMarkdownConverter
+    {
+        /// <summary>
+        /// Convert SRT to Markdown. The SRT markup is encoded in comments. The encoding itself is a JSON array of a CaptionInfo object in Base64 format.
+        /// The lines of a single utterance are combined into a single line (Microsoft does not combine lines of the markdown, as is required.)
+        /// </summary>
+        /// <param name="srtLines">The content of an SRT file in string array form.</param>
+        /// <returns>Markdown document with comments</returns>
+        public static string ConvertToMarkdown(string[] srtLines)
+        {
+            string markdownText = string.Empty;
+            string currentText = string.Empty;
+            CaptionInfo captionInfo = new();
+            foreach (string line in srtLines)
+            {
+                if (IsSequenceNumber(line, out int sequenceNumber))
+                {
+                    captionInfo.Clear();
+                    captionInfo.SequenceNumber = sequenceNumber;
+                    continue;
+                }
+                else
+                if (IsTimeCode(line))
+                {
+                    captionInfo.TimeCode = line;
+                    continue;
+                }
+                else
+                if (string.IsNullOrWhiteSpace(line)) //empty line denotes end of caption
+                {
+                    markdownText += currentText;
+                    currentText = string.Empty;
+                    markdownText += $"\n<!-- {StringCompression.Compress(JsonSerializer.Serialize(captionInfo))} -->\n";
+                    captionInfo.Clear();
+                    continue;
+                }
+                //normal caption text
+                currentText += line + " ";
+                captionInfo.StringLengths.Add(line.Length);
+            }
+            if (captionInfo.SequenceNumber > 1) //write out any unwritten caption info
+            {
+                markdownText += $"\n<!-- {StringCompression.Compress(JsonSerializer.Serialize(captionInfo))} -->\n";
+            }
+            return markdownText;
+        }
+
+        /// <summary>
+        /// Convert Markdown to SRT. The SRT markup is encoded in comments. The encoding itself is a JSON array of a CaptionInfo object in Base64 format.
+        /// </summary>
+        /// <param name="markdownText">Text in Markdown format as a string.</param>
+        /// <returns>SRT document</returns>
+        public static string ConvertToSRT(string markdownText)
+        {
+            string srtText = string.Empty;
+            string[] lines = markdownText.Split('\n');
+            string currentText = string.Empty;
+            foreach (string line in lines)
+            {
+                string line1 = line.Trim();
+                if (line1.StartsWith("<!--"))
+                {
+                    CaptionInfo captionInfo = JsonSerializer.Deserialize<CaptionInfo>(StringCompression.Decompress(line1[5..^3]));
+                    srtText += $"{captionInfo.SequenceNumber}\n{captionInfo.TimeCode}\n";
+                    //Write out the caption string split into lines
+                    srtText += SplitByLength(currentText, captionInfo.StringLengths);
+                    srtText += "\n";
+                    currentText = string.Empty;
+                    continue;
+                }
+                currentText += line1 + " ";
+            }
+            return srtText;
+        }
+
+        /// <summary>
+        /// Receive a string and a list of lengths. Split the string into lines of the given lengths, by using the nearest word break to the length.
+        /// Search forward and backward from the length to find the nearest word break. Consider punctuation as a word break opportunity.
+        /// </summary>
+        /// <param name="currentText">The text to split</param>
+        /// <param name="stringLengths">A list of desired string lengths</param>
+        /// <returns></returns>
+        private static string SplitByLength(string currentText, List<int> stringLengths)
+        {
+            if (stringLengths.Count <= 1) return currentText + "\n";
+            string result = string.Empty;
+            foreach (int length in stringLengths)
+            {
+                int forwardIndex = length;
+                int backwardIndex = length;
+                while (forwardIndex < currentText.Length && !char.IsWhiteSpace(currentText[forwardIndex]) && !char.IsPunctuation(currentText[forwardIndex]))
+                {
+                    forwardIndex++;
+                }
+                while (backwardIndex > 0 && !char.IsWhiteSpace(currentText[backwardIndex]) && !char.IsPunctuation(currentText[backwardIndex]))
+                {
+                    backwardIndex--;
+                }
+                int index = Math.Abs(length - forwardIndex) < Math.Abs(length - backwardIndex) ? forwardIndex : backwardIndex;
+                if (index >= currentText.Length) index = currentText.Length - 1;
+                result += string.Concat(currentText.AsSpan(0, index), "\n");
+                currentText = currentText[index..];
+                if (currentText.Length == 0) break;
+                if (currentText[0] == ' ') currentText = currentText[1..];
+                if (currentText.Length <= 2)
+                {
+                    result += currentText;
+                    break;
+                }
+            }
+            return result;
+        }
+
+
+
+        /// <summary>
+        /// Determine if a line is a SRT style time code. Time codes are in the format hh:mm:ss,fff --> hh:mm:ss,fff
+        /// </summary>
+        /// <param name="line">A line of the SRT file.</param>
+        /// <returns>Whether the line contains an SRT style time code.</returns>
+        private static bool IsTimeCode(string line)
+        {
+            string timeCodePattern = @"\d{2}:\d{2}:\d{2},\d{3}\s-->\s\d{2}:\d{2}:\d{2},\d{3}";
+
+            return System.Text.RegularExpressions.Regex.IsMatch(line, timeCodePattern, System.Text.RegularExpressions.RegexOptions.Compiled);
+        }
+
+        /// <summary>
+        /// Determine if a line is a sequence number. SRT style sequence numbers are one integer on a line by itself.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="sequenceNumber"></param>
+        /// <returns></returns>
+        private static bool IsSequenceNumber(string line, out int sequenceNumber)
+        {
+            return int.TryParse(line, out sequenceNumber);
+        }
+
+    }
+}

--- a/LocalFormats/SRTMarkdownConverter.cs
+++ b/LocalFormats/SRTMarkdownConverter.cs
@@ -134,8 +134,8 @@ namespace SRT2Markdown
         /// <summary>
         /// Determine if a line is a sequence number. SRT style sequence numbers are one integer on a line by itself.
         /// </summary>
-        /// <param name="line"></param>
-        /// <param name="sequenceNumber"></param>
+        /// <param name="line">A line of the SRT file</param>
+        /// <param name="sequenceNumber">If there is a single number on the line, return it.</param>
         /// <returns></returns>
         private static bool IsSequenceNumber(string line, out int sequenceNumber)
         {

--- a/LocalFormats/SRTMarkdownConverter.cs
+++ b/LocalFormats/SRTMarkdownConverter.cs
@@ -8,15 +8,18 @@ namespace SRT2Markdown
     {
         /// <summary>
         /// Convert SRT to Markdown. The SRT markup is encoded in comments. The encoding itself is a JSON array of a CaptionInfo object in Base64 format.
-        /// The lines of a single utterance are combined into a single line (Microsoft does not combine lines of the markdown, as is required.)
+        /// The lines of a single caption are combined into a single line (Microsoft does not combine lines of the markdown, as is required.)
         /// </summary>
         /// <param name="srtLines">The content of an SRT file in string array form.</param>
         /// <returns>Markdown document with comments</returns>
         public static string ConvertToMarkdown(string[] srtLines)
         {
+            ///TODO: This currently only combines the lines from a single caption. However, often a sentence continues over multiple captions.
+            ///It would be better to combine multiple captions and translate as a complete sentence after sent end punc is found, and then split them
+            ///out again over multiple captions after translation. 
             string markdownText = string.Empty;
             string currentText = string.Empty;
-            CaptionInfo captionInfo = new();
+            SRTCaptionInfo captionInfo = new();
             foreach (string line in srtLines)
             {
                 if (IsSequenceNumber(line, out int sequenceNumber))
@@ -65,7 +68,7 @@ namespace SRT2Markdown
             {
                 if (line.StartsWith("<!--"))
                 {
-                    CaptionInfo captionInfo = JsonSerializer.Deserialize<CaptionInfo>(StringCompression.Decompress(line[5..^3]));
+                    SRTCaptionInfo captionInfo = JsonSerializer.Deserialize<SRTCaptionInfo>(StringCompression.Decompress(line[5..^3]));
                     srtText += $"{captionInfo.SequenceNumber}\n{captionInfo.TimeCode}\n";
                     //Write out the caption string split into lines
                     srtText += SplitByLength(currentText, captionInfo.StringLengths);

--- a/LocalFormats/SRTMarkdownConverter.cs
+++ b/LocalFormats/SRTMarkdownConverter.cs
@@ -1,4 +1,6 @@
 ﻿using System.Text.Json;
+using System.Collections.Generic;
+using System;
 
 namespace SRT2Markdown
 {

--- a/LocalFormats/StringCompression.cs
+++ b/LocalFormats/StringCompression.cs
@@ -1,0 +1,56 @@
+﻿using System.IO.Compression;
+using System.Text;
+
+namespace SRT2Markdown
+{
+    public static class StringCompression
+    {
+        /// <summary>
+        /// Compresses a string and returns a deflate compressed, Base64 encoded string.
+        /// </summary>
+        /// <param name="uncompressedString">String to compress</param>
+        public static string Compress(string uncompressedString)
+        {
+            byte[] compressedBytes;
+
+            using (var uncompressedStream = new MemoryStream(Encoding.UTF8.GetBytes(uncompressedString)))
+            {
+                using var compressedStream = new MemoryStream();
+                // setting the leaveOpen parameter to true to ensure that compressedStream will not be closed when compressorStream is disposed
+                // this allows compressorStream to close and flush its buffers to compressedStream and guarantees that compressedStream.ToArray() can be called afterward
+                // although MSDN documentation states that ToArray() can be called on a closed MemoryStream, I don't want to rely on that very odd behavior should it ever change
+                using (var compressorStream = new DeflateStream(compressedStream, CompressionLevel.Fastest, true))
+                {
+                    uncompressedStream.CopyTo(compressorStream);
+                }
+
+                // call compressedStream.ToArray() after the enclosing DeflateStream has closed and flushed its buffer to compressedStream
+                compressedBytes = compressedStream.ToArray();
+            }
+
+            return Convert.ToBase64String(compressedBytes);
+        }
+
+        /// <summary>
+        /// Decompresses a deflate compressed, Base64 encoded string and returns an uncompressed string.
+        /// </summary>
+        /// <param name="compressedString">String to decompress.</param>
+        public static string Decompress(string compressedString)
+        {
+            byte[] decompressedBytes;
+
+            var compressedStream = new MemoryStream(Convert.FromBase64String(compressedString));
+
+            using (var decompressorStream = new DeflateStream(compressedStream, CompressionMode.Decompress))
+            {
+                using var decompressedStream = new MemoryStream();
+                decompressorStream.CopyTo(decompressedStream);
+
+                decompressedBytes = decompressedStream.ToArray();
+            }
+
+            return Encoding.UTF8.GetString(decompressedBytes);
+        }
+    }
+
+}

--- a/LocalFormats/StringCompression.cs
+++ b/LocalFormats/StringCompression.cs
@@ -1,5 +1,9 @@
-﻿using System.IO.Compression;
+﻿using System;
+using System.IO;
+using System.IO.Compression;
 using System.Text;
+
+///Credit: https://stackoverflow.com/questions/7343465/compression-decompression-string-with-c-sharp
 
 namespace SRT2Markdown
 {


### PR DESCRIPTION
Adding converters between a service document format and a service-unavailable format. Here: Convert SRT to MarkDown, translate MarkDown, then convert to translated SRT.